### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@ http://dev.evernote.com/documentation/cloud/chapters/thumbnails.php
 
 ### Installation
 
-* Cocoapods: Search and install with SSEvernoteSDKPatch
+* CocoaPods: Search and install with SSEvernoteSDKPatch
 * Manual: Drag EvernoteNoteStore+SSPatch.h and EvernoteNoteStore+SSPatch.m into your project
 
 ### How to use (Sample)


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
